### PR TITLE
Remove header title and subtitle from frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chatbot</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
@@ -14,8 +14,6 @@
         <header>
             <div class="header-content">
                 <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
                 </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
                     <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
Fixes #2

Removed header components as requested:
- Removed "Course Materials Assistant" header text
- Removed "Ask questions about courses, instructors, and content" subtitle
- Updated page title to "RAG Chatbot"
- Kept horizontal bar and theme toggle button

Generated with [Claude Code](https://claude.ai/code)